### PR TITLE
Use https protocol for file-saver git location

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -26,7 +26,7 @@
     "jszip": "2.5.0",
     "localforage": "1.2.7",
     "traceur": "0.0.111",
-    "file-saver": "git@github.com:eligrey/FileSaver.js.git#72effad",
+    "file-saver": "https://github.com/eligrey/FileSaver.js.git#72effad",
     "underscore": "1.9.1"
   },
   "resolutions": {


### PR DESCRIPTION
The version of Bower in Ubuntu 18.04 seems to struggle to use git protocol URLs for repos, at least when talking to GitHub.